### PR TITLE
fix(input): change `togglePassword` button type to `button`

### DIFF
--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -161,6 +161,7 @@ export const Input = forwardRef(
               className="show-password-button"
               aria-label={togglePasswordLabel}
               onClick={() => setIsPassword(old => !old)}
+              type="button"
             />
           )}
           {children}


### PR DESCRIPTION
Because the default type of **button** is `submit` this will trigger the parent `form` to emit the `onSubmit` event.